### PR TITLE
Add support for keys() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ npm-debug.log*
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
-
 coverage

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var crypto = require('crypto');
 var path = require('path');
 var async = require('async');
 var extend = require('extend');
+var uuid = require('uuid');
 
 /**
  * Export 'DiskStore'
@@ -141,7 +142,7 @@ DiskStore.prototype.set = function (key, val, options, cb) {
   	key: key,
   	value: val,
   	expires: Date.now() + ((ttl || 60) * 1000),
-  	filename: this.options.path + '/cache_' + crypto.randomBytes(4).readUInt32LE(0) + '.dat'
+  	filename: this.options.path + '/cache_' + uuid.v4() + '.dat'
   });
 
   var stream = JSON.stringify(metaData);

--- a/index.js
+++ b/index.js
@@ -312,6 +312,19 @@ DiskStore.prototype.get = function (key, cb) {
 };
 
 /**
+ * get keys stored in cache
+ * @param {Function} cb
+ */
+DiskStore.prototype.keys = function (cb) {
+
+	cb = typeof cb === 'function' ? cb : noop;
+
+	var keys = Object.keys(this.collection);
+
+	cb(null, keys);
+};
+
+/**
  * cleanup cache on disk -> delete all used files from the cache
  */
 DiskStore.prototype.reset = function (key, cb) {

--- a/package.json
+++ b/package.json
@@ -17,17 +17,18 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "coverage" : "npm run create-coverage && npm run show-coverage",
+    "coverage": "npm run create-coverage && npm run show-coverage",
     "create-coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec -t 5000",
-    "show-coverage" : "start coverage\\lcov-report\\index.html"
+    "show-coverage": "start coverage\\lcov-report\\index.html"
   },
   "author": "Markus Pfann",
   "license": "ISC",
   "dependencies": {
     "async": "^1.4.2",
-    "cache-manager": "^1.1.0",    
+    "cache-manager": "^1.1.0",
     "extend": "^3.0.0",
-    "fs-promise": "^0.3.1"
+    "fs-promise": "^0.3.1",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ var cacheDirectory = 'test/customCache';
 
 describe('test for the hde-disk-store module', function () {
 
-	// remove test directory after run	
+	// remove test directory after run
 	after(function (done) {
 		// create a test store
 		var s=store.create({options: {path:cacheDirectory, preventfill:true}});
@@ -17,33 +17,33 @@ describe('test for the hde-disk-store module', function () {
 			setTimeout(function () {
 
 				fs.rmdirSync(s.options.path);
-				done(); 				
-			}, 100);			
-		}); 
+				done();
+			}, 100);
+			});
 	});
 
 	describe('construction', function () {
 
 		it('simple create cache test', function ()
-		{								
-			// create a store with default values	
+		{
+			// create a store with default values
 			var s = store.create();
-			// remove folder after testrun 
+			// remove folder after testrun
 			after(function () { fs.rmdirSync(s.options.path); });
-			// check the creation result	
+			// check the creation result
 			assert.isObject(s);
 			assert.isObject(s.options);
 			assert.isTrue(fs.existsSync(s.options.path));
 		});
 
 		it('create cache with option path test', function () {
-			// create a store								
+			// create a store
 			var s = store.create({options: {path:cacheDirectory, preventfill:true}});
-			// check path option creation			
+			// check path option creation
 			assert.isObject(s);
 			assert.isObject(s.options);
 			assert.isTrue(fs.existsSync(s.options.path));
-			assert(s.options.path == cacheDirectory);		
+			assert(s.options.path == cacheDirectory);
 		});
 	});
 
@@ -51,76 +51,76 @@ describe('test for the hde-disk-store module', function () {
 
 		it('simple get test with not existing key', function (done)
 		{
-			var s=store.create({options: {path:cacheDirectory, preventfill:true}});			
+			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 			s.get('asdf', function (err, data)
 			{
-				assert(data === null);	
-				done();			
-			});			
+				assert(data === null);
+				done();
+			});
 		});
-		
+
 		describe('test missing file on disk', function() {
 			it('filename empty', function (done){
 				var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 				s.set('test','test', function (err)
 				{
 					assert(err === null);
-					var tmpfilename = s.collection['test'].filename; 
+					var tmpfilename = s.collection['test'].filename;
 					s.collection['test'].filename = null;
 					s.get('test', function (err,data) {
 						assert(err !== null);
-						assert(data == null);						
+						assert(data == null);
 						s.collection['test'].filename = tmpfilename;
 						s.del('test', function (err)
 						{
 							assert(err == null);
 							done();
-						});									
-					})						
+						});
+					})
 				});
 			});
-	
+
 			it('file does not exist', function (done){
 				var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 				s.set('test','test', function (err)
 				{
 					assert(err === null);
-					var tmpfilename = s.collection['test'].filename; 
+					var tmpfilename = s.collection['test'].filename;
 					s.collection['test'].filename = "bla";
 					s.get('test', function (err,data) {
 						assert(err !== null);
-						assert(data == null);						
+						assert(data == null);
 						s.collection['test'].filename = tmpfilename;
 						s.del('test', function (err)
 						{
 							assert(err == null);
 							done();
-						});									
-					})						
+						});
+					})
 				});
-			});			
+			});
 		});
-		
+
 		it('test expired of key (and also ttl option on setting)', function (done)
 		{
-			var s=store.create({options: {path:cacheDirectory, preventfill:true}});			
+			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 			s.set('asdf','blabla', {ttl:-1000}, function (err)
 			{
 				assert(err === null)
-				s.get('asdf',function (err,data){				
+				s.get('asdf',function (err,data){
 					assert(err === null, 'error is not null!'+err);
-					assert(data === null);		
-					done();		
+					assert(data === null);
+					done();
 				})
 			});
 		})
 	});
 
-	describe('set', function () {	
+	describe('set', function () {
 
 		it('simple set test', function (done)
-		{			
-			var s=store.create({options: {path:cacheDirectory, preventfill:true}});					
+		{
+			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 			var data = 'a lot of data in a file'
 			s.set('asdf',data, function (err,data2)
 			{
@@ -130,10 +130,10 @@ describe('test for the hde-disk-store module', function () {
 				{
 					assert(data2,'check if entry could be retrieved');
 					assert(data === data2);
-					done();				
-				});				
-			});									
-		});	
+					done();
+				});
+			});
+		});
 	});
 
 	describe('keys', function() {
@@ -160,7 +160,7 @@ describe('test for the hde-disk-store module', function () {
 			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 			s.del('not existing', function (err) {
 				done();
-			});			
+			});
 		});
 
 		it('successfull deletion', function (done)
@@ -169,11 +169,11 @@ describe('test for the hde-disk-store module', function () {
 			s.set('nix','empty', function (err) {
 				assert(err === null);
 				s.reset('nix', function (err) {
-					done();	
-				});							
-			});			
+					done();
+				});
+			});
 		});
-		
+
 		describe('delete errorhandling', function() {
 			it('file not exists', function(done) {
 				var s=store.create({options: {path:cacheDirectory, preventfill:true}});
@@ -185,11 +185,11 @@ describe('test for the hde-disk-store module', function () {
 						s.collection['test'].filename = fn;
 						assert(err==null);
 						done();
-					});				
+					});
 				})
 			});
-	
-			
+
+
 			it('filename not set', function(done) {
 				var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 				s.set('test','empty', function(err) {
@@ -200,12 +200,31 @@ describe('test for the hde-disk-store module', function () {
 						s.collection['test'].filename = fn;
 						assert(err==null);
 						done();
-					});				
+					});
 				})
 			});
-			
+
 		})
-		
+
+		it('reset all', function(done) {
+			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
+			s.set('test', 'test', function(err){
+				assert(err === null);
+
+				s.set('test2', 'test2', function(err) {
+					assert(err === null);
+					s.reset(function(err) {
+						assert(err === null);
+
+						s.keys(function(err, keys) {
+							assert(err === null);
+							assert(keys.length === 0);
+							done();
+						});
+					});
+				});
+			});
+		});
 
 		it('reset callback', function (done)
 		{
@@ -226,7 +245,7 @@ describe('test for the hde-disk-store module', function () {
 		it('works', function () {
 			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
 			assert(!s.isCacheableValue(null));
-			assert(!s.isCacheableValue(undefined));									
+			assert(!s.isCacheableValue(undefined));
 		});
 	});
 
@@ -248,11 +267,11 @@ describe('test for the hde-disk-store module', function () {
 								assert(err === null);
 								assert(data === null);
 								assert(s.currentsize > 0, 'current size not correctly initialized - '+s.currentsize);
-								done();	
-							});							
-						});										
+								done();
+							});
+						});
 					}
-					}});				
+					}});
 				});
 			});
 		});
@@ -262,8 +281,8 @@ describe('test for the hde-disk-store module', function () {
 			// create store
 			var s = store.create({
 				options: {
-					path: cacheDirectory, 
-					preventfill: true, 
+					path: cacheDirectory,
+					preventfill: true,
 					maxsize: 1
 				}
 			});
@@ -274,13 +293,13 @@ describe('test for the hde-disk-store module', function () {
 
 				s.set('x', 'x', { ttl: -1 }, function (err, val) {
 					assert(err === 'Item size too big.');
-					assert(Object.keys(s.collection).length === 0);						
+					assert(Object.keys(s.collection).length === 0);
 
 					s.options.maxsize = 150;
 					s.set('a', 'a', { ttl: 10000 }, function (err, val) {
 						assert(err === null);
 						assert(Object.keys(s.collection).length === 1);
-						
+
 						s.set('b', 'b', { ttl: 100 }, function (err){
 							assert(err === null);
 
@@ -295,7 +314,7 @@ describe('test for the hde-disk-store module', function () {
 									s.get('b', function (err,data){
 										assert(err === null);
 										assert(data === null);
-										done();													
+										done();
 									});
 								});
 							});
@@ -303,6 +322,6 @@ describe('test for the hde-disk-store module', function () {
 					});
 				});
 			});
-		});		
+		});
 	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -136,6 +136,23 @@ describe('test for the hde-disk-store module', function () {
 		});	
 	});
 
+	describe('keys', function() {
+
+		it('simple keys test', function (done) {
+			var s=store.create({options: {path:cacheDirectory, preventfill:true}});
+			var data = 'just a string with data';
+			s.set('key123', data, function (err, data2) {
+				assert(err === null);
+				s.keys(function(err, keys) {
+					assert(err === null);
+					assert(keys.length === 1);
+					assert(keys[0] === 'key123');
+					done();
+				});
+			});
+		});
+	});
+
 	describe('del / reset', function () {
 
 		it('simple del test for not existing key', function (done)


### PR DESCRIPTION
First of all, thanks for the great adapter for node-cache-manager.

I'm currently working on a project in which i require local file storage to through a universal API. 
In this project i required a additional method to fetch all keys from the cache, this PR contains support for this method.

The original `node-cache-manager` npm module has the about the same mechanism for the keys method when using the memory storage. (see: https://github.com/BryanDonovan/node-cache-manager/blob/master/lib/stores/memory.js#L64)
