### PR TITLE
Updating to match node-cache-manager API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,7 +297,7 @@ DiskStore.prototype.freeupspacehelper = function (tuples, cb) {
 /**
  * get entry from the cache
  */
-DiskStore.prototype.get = function (key, cb) {
+DiskStore.prototype.get = function (key, options, cb) {
 
 	cb = typeof cb === 'function' ? cb : noop;
 


### PR DESCRIPTION
As pointed out in issue #2, this change needs to be made or the callback method is never called.
