### PR TITLE
buffers put to cache returned as buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ options.path = 'cache/'; // path for cached files
 options.preventfill = false; // prevent filling of the cache with the files from the cache-directory
 options.fillcallback = null; // callback fired after the initial cache filling is completed
 options.zip = false; // if true the cached files will be zipped to save diskspace
+options.bufferReviver = true; // if true buffers are returned from cache as buffers, not objects
 
 ```
 ## Installation

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ options.path = 'cache/'; // path for cached files
 options.preventfill = false; // prevent filling of the cache with the files from the cache-directory
 options.fillcallback = null; // callback fired after the initial cache filling is completed
 options.zip = false; // if true the cached files will be zipped to save diskspace
-options.bufferReviver = true; // if true buffers are returned from cache as buffers, not objects
+options.reviveBuffers = true; // if true buffers are returned from cache as buffers, not objects
 
 ```
 ## Installation

--- a/index.js
+++ b/index.js
@@ -348,23 +348,23 @@ DiskStore.prototype.get = function (key, options, cb) {
                     zlib.unzip(fileContent, function(err, buffer)
                     {
                         var diskdata;
-			if(reviveBuffers) {
-				diskdata = JSON.parse(buffer, bufferReviver);
-			} else {
-				diskdata = JSON.parse(buffer);
-			}
+                        if(reviveBuffers) {
+                            diskdata = JSON.parse(buffer, bufferReviver);
+                        } else {
+                            diskdata = JSON.parse(buffer);
+                        }
                         cb(null, diskdata.value);                                            
                     });
                 }
                 else
                 {
-                    	var diskdata;
-			if(reviveBuffers) {
-				diskdata = JSON.parse(buffer, bufferReviver);
-			} else {
-				diskdata = JSON.parse(buffer);
-			}
-                    	cb(null, diskdata.value);                    
+                    var diskdata;
+                    if(reviveBuffers) {
+                        diskdata = JSON.parse(buffer, bufferReviver);
+                    } else {
+                        diskdata = JSON.parse(buffer);
+                    }
+                    cb(null, diskdata.value);
                 }
 			}.bind(this));
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,22 @@ module.exports = {
 };
 
 /**
+ * Helper function that revives buffers from object representation on JSON.parse
+ */
+function bufferReviver(k, v) {
+	if (
+		v !== null &&
+		typeof v === 'object' &&
+		'type' in v &&
+		v.type === 'Buffer' &&
+		'data' in v &&
+		Array.isArray(v.data)) {
+		return new Buffer(v.data);
+	}
+	return v;
+}
+
+/**
  * helper object with meta-informations about the cached data
  */
 function MetaData () {
@@ -330,13 +346,13 @@ DiskStore.prototype.get = function (key, options, cb) {
                 {
                     zlib.unzip(fileContent, function(err, buffer)
                     {
-                        var diskdata = JSON.parse(buffer);
+                        var diskdata = JSON.parse(buffer, bufferReviver);
                         cb(null, diskdata.value);                                            
                     });
                 }
                 else
                 {
-                    var diskdata = JSON.parse(fileContent);
+                    var diskdata = JSON.parse(fileContent, bufferReviver);
                     cb(null, diskdata.value);                    
                 }
 			}.bind(this));

--- a/index.js
+++ b/index.js
@@ -358,13 +358,13 @@ DiskStore.prototype.get = function (key, options, cb) {
                 }
                 else
                 {
-                    var diskdata;
-                    if(reviveBuffers) {
-                        diskdata = JSON.parse(buffer, bufferReviver);
-                    } else {
-                        diskdata = JSON.parse(buffer);
-                    }
-                    cb(null, diskdata.value);
+					var diskdata;
+					if (reviveBuffers) {
+						diskdata = JSON.parse(fileContent, bufferReviver);
+					} else {
+						diskdata = JSON.parse(fileContent);
+					}
+					cb(null, diskdata.value);
                 }
 			}.bind(this));
 

--- a/index.js
+++ b/index.js
@@ -342,18 +342,29 @@ DiskStore.prototype.get = function (key, options, cb) {
 				if (err) {
 					return cb(err);
 				}
+		var reviveBuffers = this.options.reviveBuffers;
                 if (this.options.zip)
                 {
                     zlib.unzip(fileContent, function(err, buffer)
                     {
-                        var diskdata = JSON.parse(buffer, bufferReviver);
+                        var diskdata;
+			if(reviveBuffers) {
+				diskdata = JSON.parse(buffer, bufferReviver);
+			} else {
+				diskdata = JSON.parse(buffer);
+			}
                         cb(null, diskdata.value);                                            
                     });
                 }
                 else
                 {
-                    var diskdata = JSON.parse(fileContent, bufferReviver);
-                    cb(null, diskdata.value);                    
+                    	var diskdata;
+			if(reviveBuffers) {
+				diskdata = JSON.parse(buffer, bufferReviver);
+			} else {
+				diskdata = JSON.parse(buffer);
+			}
+                    	cb(null, diskdata.value);                    
                 }
 			}.bind(this));
 


### PR DESCRIPTION
Buffers are turned into objects of the following structure: {type: "Buffer", data: [0, 1, 2]}
When JSON.parse is called, buffers remain in the object form
This adds a reviver to JSON.parse to get buffers back as buffers

This could probably break things if people already use this with buffers. So, I wonder why no one came up with the solution yet.

We should probably add an option to use the buffer reviver, defaulted to false, so current code will not break, but the easy option will be working.
#4
