### PR TITLE
Added options arg to del operation to support new cache managers

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,12 @@ DiskStore.prototype.isCacheableValue = function (value) {
 /**
  * delete an entry from the cache
  */
-DiskStore.prototype.del = function (key, cb) {
-
+DiskStore.prototype.del = function (key, options, cb) {
+  
+  if (typeof options === 'function') {
+        cb = options;
+        options = null;
+  }
   cb = typeof cb === 'function' ? cb : noop;
 
   // get the metainformations for the key


### PR DESCRIPTION
Previously, node-cache-manager-fs could not support multicache delete operations ([such as this one](https://github.com/BryanDonovan/node-cache-manager/blob/master/lib/multi_caching.js#L619)) that had an options arg. This PR adds support for such deletion operations while maintaining support for legacy deletion operations.